### PR TITLE
add safeguard for qt4's moc to skip boost header

### DIFF
--- a/include/fps_motion_tool.h
+++ b/include/fps_motion_tool.h
@@ -36,12 +36,15 @@
 #include <ros/console.h>
 #include <rviz/viewport_mouse_event.h>
 #include <rviz/visualization_manager.h>
-#include <rviz/mesh_loader.h>
 #include <rviz/geometry.h>
 #include <rviz/properties/vector_property.h>
 #include <rviz/tool.h>
 #include <rviz/tool_manager.h>
 #include <rviz/display_group.h>
+
+#ifndef Q_MOC_RUN
+#include <rviz/mesh_loader.h>
+#endif
 
 #include "rviz/display_context.h"
 #include "rviz/render_panel.h"


### PR DESCRIPTION
It is a well-known problem qt4's moc can't handle preprocessor variables and
therefore breaks at a number of places with boost. Boost 1.57 added one more
that makes it impossible to have ogre includes in code moc has to process....
