### PR TITLE
Add ROS Kinetic compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,19 +8,13 @@ link_directories(${catkin_LIBRARY_DIRS})
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -std=c++0x" )
 
 ## This plugin includes Qt widgets, so we must include Qt like so:
-find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-include(${QT_USE_FILE})
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Gui REQUIRED)
+find_package(Qt5Widgets REQUIRED)
 
 ## I prefer the Qt signals and slots to avoid defining "emit", "slots",
 ## etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
 add_definitions(-DQT_NO_KEYWORDS)
-
-## Here we specify which header files need to be run through "moc",
-## Qt's meta-object compiler.
-qt4_wrap_cpp(MOC_FILES
-  include/fps_motion_view_controller.h
-  include/fps_motion_tool.h
-)
 
 catkin_package(
   DEPENDS
@@ -42,6 +36,13 @@ set(SOURCE_FILES
   ${MOC_FILES}
 )
 
+## Here we specify which header files need to be run through "moc",
+## Qt's meta-object compiler.
+qt5_wrap_cpp(SOURCE_FILES
+  include/fps_motion_view_controller.h
+  include/fps_motion_tool.h
+)
+
 ## An rviz plugin is just a shared library, so here we declare the
 ## library to be called ``${PROJECT_NAME}``
 
@@ -49,7 +50,7 @@ add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 ## Link the library with whatever Qt libraries have been defined by
 ## the ``find_package(Qt4 ...)`` line above.
-target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::Gui Qt5::Core ${catkin_LIBRARIES})
 
 install(TARGETS
   ${PROJECT_NAME}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 rviz_fps_plugin
 ===============
 
+*Now compatible with ROS Kinetic (and possibly newer ROS distros)!*
+
 ## Overview
 
 The rviz_fps_plugin package contains an additional ViewController and a Tool Plugin to navigate RViz like an FPS-Shooter using the keyboard.


### PR DESCRIPTION
Fixes CMakeLists.txt to provide QT5 compatibility. Tested with ROS Kinetic and works! Might work with newer ROS distros as well. This is a cool RViz plugin and I hope others can continue to use it.

I can only make the pull request to an existing branch on upstream, but this should probably eventually go in a branch called `kinetic` based on the current naming.